### PR TITLE
Add gosec, errorlint, bodyclose, gocritic linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,10 @@ linters:
     - unparam
     - unused
     - govet
+    - gosec
+    - errorlint
+    - bodyclose
+    - gocritic
 
 formatters:
   enable:

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -8,6 +8,11 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
+	"io"
+	"os"
+	"time"
+
 	as "github.com/aerospike/aerospike-client-go/v8"
 	astypes "github.com/aerospike/aerospike-client-go/v8/types"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
@@ -19,9 +24,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"io"
-	"os"
-	"time"
 )
 
 // Ensure AerospikeProvider satisfies various provider interfaces.
@@ -134,7 +136,7 @@ func (p *AerospikeProvider) Configure(ctx context.Context, req provider.Configur
 		cp.Timeout = time.Second * time.Duration(connectTimeout)
 	}
 
-	//TLS
+	// TLS
 	var tlsEnabled bool
 	var tlsConfig tls.Config
 
@@ -144,7 +146,7 @@ func (p *AerospikeProvider) Configure(ctx context.Context, req provider.Configur
 		tlsEnabled = true
 		data.TLS.As(ctx, &dataTLS, basetypes.ObjectAsOptions{})
 
-		//read the root ca if supplied
+		// read the root ca if supplied
 		if !dataTLS.RootCAFile.IsNull() {
 			file, err := os.Open(dataTLS.RootCAFile.ValueString())
 			if err != nil {
@@ -163,7 +165,7 @@ func (p *AerospikeProvider) Configure(ctx context.Context, req provider.Configur
 			// Read the file into a byte slice
 			bs := make([]byte, stat.Size())
 			_, err = bufio.NewReader(file).Read(bs)
-			if err != nil && err != io.EOF {
+			if err != nil && !errors.Is(err, io.EOF) {
 				resp.Diagnostics.Append(diag.NewErrorDiagnostic("Error reading root ca file", err.Error()))
 				return
 			}

--- a/internal/provider/resource_aerospike_role.go
+++ b/internal/provider/resource_aerospike_role.go
@@ -9,6 +9,7 @@ import (
 	as "github.com/aerospike/aerospike-client-go/v8"
 	astypes "github.com/aerospike/aerospike-client-go/v8/types"
 	"github.com/ghetzel/go-stockutil/sliceutil"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -22,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"math"
 	"reflect"
 	"strings"
 )
@@ -115,12 +117,18 @@ func (r *AerospikeRole) Schema(ctx context.Context, req resource.SchemaRequest, 
 				Optional:    true,
 				Computed:    true,
 				Default:     int64default.StaticInt64(0),
+				Validators: []validator.Int64{
+					int64validator.Between(0, math.MaxUint32),
+				},
 			},
 			"write_quota": schema.Int64Attribute{
 				Description: "write quota to apply to the role",
 				Optional:    true,
 				Computed:    true,
 				Default:     int64default.StaticInt64(0),
+				Validators: []validator.Int64{
+					int64validator.Between(0, math.MaxUint32),
+				},
 			},
 		},
 	}
@@ -158,8 +166,8 @@ func (r *AerospikeRole) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 
 	roleName := data.Role_name.ValueString()
-	readQuota := uint32(data.Read_quota.ValueInt64())
-	writeQuota := uint32(data.Write_quota.ValueInt64())
+	readQuota := uint32(data.Read_quota.ValueInt64())   //nolint:gosec // schema validator ensures 0..MaxUint32
+	writeQuota := uint32(data.Write_quota.ValueInt64()) //nolint:gosec // schema validator ensures 0..MaxUint32
 
 	privElements := make([]types.Object, 0, len(data.Privileges.Elements()))
 	data.Privileges.ElementsAs(ctx, &privElements, false)
@@ -288,7 +296,7 @@ func (r *AerospikeRole) Update(ctx context.Context, req resource.UpdateRequest, 
 
 	data.Role_name = plan.Role_name
 
-	//privileges
+	// privileges
 	if reflect.DeepEqual(plan.Privileges, state.Privileges) {
 		data.Privileges = plan.Privileges
 	} else {
@@ -353,7 +361,7 @@ func (r *AerospikeRole) Update(ctx context.Context, req resource.UpdateRequest, 
 
 	}
 
-	//whitelist
+	// whitelist
 	if !reflect.DeepEqual(plan.White_list, state.White_list) {
 		whiteList := make([]string, 0)
 		for _, w := range plan.White_list {
@@ -366,10 +374,10 @@ func (r *AerospikeRole) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 	data.White_list = plan.White_list
 
-	//qoutas
+	// quotas
 	if plan.Read_quota != state.Read_quota || plan.Write_quota != state.Write_quota {
-		err := r.asConn.client.SetQuotas(adminPol, data.Role_name.ValueString(), uint32(plan.Read_quota.ValueInt64()),
-			uint32(plan.Write_quota.ValueInt64()))
+		err := r.asConn.client.SetQuotas(adminPol, data.Role_name.ValueString(), uint32(plan.Read_quota.ValueInt64()), //nolint:gosec // schema validator ensures 0..MaxUint32
+			uint32(plan.Write_quota.ValueInt64())) //nolint:gosec // schema validator ensures 0..MaxUint32
 		if err != nil && err.Matches(astypes.QUOTAS_NOT_ENABLED) {
 			resp.Diagnostics.Append(diag.NewErrorDiagnostic("Quotas not enabled", "Role quotas are requests but not enabled in the server"))
 			return

--- a/internal/provider/resource_aerospike_role_test.go
+++ b/internal/provider/resource_aerospike_role_test.go
@@ -33,7 +33,7 @@ func testAccCheckAerospikeRoleDestroy(s *terraform.State) error {
 			return fmt.Errorf("aerospike role %s still exists", rs.Primary.Attributes["role_name"])
 		}
 		if !queryErr.Matches(astypes.INVALID_ROLE) {
-			return fmt.Errorf("unexpected error checking role %s: %s", rs.Primary.Attributes["role_name"], queryErr)
+			return fmt.Errorf("unexpected error checking role %s: %w", rs.Primary.Attributes["role_name"], queryErr)
 		}
 	}
 	return nil
@@ -440,7 +440,7 @@ func testAccCheckRoleExists(roleName string) resource.TestCheckFunc {
 		adminPol := as.NewAdminPolicy()
 		_, queryErr := client.QueryRole(adminPol, roleName)
 		if queryErr != nil {
-			return fmt.Errorf("role %s does not exist: %s", roleName, queryErr)
+			return fmt.Errorf("role %s does not exist: %w", roleName, queryErr)
 		}
 		return nil
 	}
@@ -461,7 +461,7 @@ func testAccCheckRoleNotExists(roleName string) resource.TestCheckFunc {
 			return fmt.Errorf("role %s still exists, expected it to be deleted", roleName)
 		}
 		if !queryErr.Matches(astypes.INVALID_ROLE) {
-			return fmt.Errorf("unexpected error checking role %s: %s", roleName, queryErr)
+			return fmt.Errorf("unexpected error checking role %s: %w", roleName, queryErr)
 		}
 		return nil
 	}

--- a/internal/provider/resource_aerospike_user_test.go
+++ b/internal/provider/resource_aerospike_user_test.go
@@ -32,7 +32,7 @@ func testAccCheckAerospikeUserDestroy(s *terraform.State) error {
 			return fmt.Errorf("aerospike user %s still exists", rs.Primary.Attributes["user_name"])
 		}
 		if !queryErr.Matches(astypes.INVALID_USER) {
-			return fmt.Errorf("unexpected error checking user %s: %s", rs.Primary.Attributes["user_name"], queryErr)
+			return fmt.Errorf("unexpected error checking user %s: %w", rs.Primary.Attributes["user_name"], queryErr)
 		}
 	}
 	return nil
@@ -173,7 +173,7 @@ func testAccCheckUserHasRoles(userName string, expectedRoles []string) resource.
 		adminPol := as.NewAdminPolicy()
 		user, queryErr := client.QueryUser(adminPol, userName)
 		if queryErr != nil {
-			return fmt.Errorf("failed to query user %s: %s", userName, queryErr)
+			return fmt.Errorf("failed to query user %s: %w", userName, queryErr)
 		}
 
 		actualSet := make(map[string]bool)
@@ -359,7 +359,7 @@ func testAccCheckUserNotExists(userName string) resource.TestCheckFunc {
 			return fmt.Errorf("user %s still exists, expected it to be deleted", userName)
 		}
 		if !queryErr.Matches(astypes.INVALID_USER) {
-			return fmt.Errorf("unexpected error checking user %s: %s", userName, queryErr)
+			return fmt.Errorf("unexpected error checking user %s: %w", userName, queryErr)
 		}
 		return nil
 	}

--- a/internal/provider/resource_aerospike_xdr_dc_config.go
+++ b/internal/provider/resource_aerospike_xdr_dc_config.go
@@ -870,14 +870,14 @@ func (r *AerospikeXDRDCConfig) diffSetPolicy(_ context.Context, dc, namespace st
 		// These are internal cleanup commands — not included in info_commands.
 		oldShipSets := extractOldSets(oldPolicy, func(p XDRSetPolicyModel) types.Set { return p.ShipSets })
 		for s := range oldShipSets {
-			addXDRDCNamespaceIgnoreSet(r.asConn.client, dc, namespace, s) //nolint:errcheck // best-effort cleanup
-			addXDRDCNamespaceShipSet(r.asConn.client, dc, namespace, s)   //nolint:errcheck // best-effort cleanup
+			addXDRDCNamespaceIgnoreSet(r.asConn.client, dc, namespace, s) //nolint:errcheck,gosec // best-effort cleanup
+			addXDRDCNamespaceShipSet(r.asConn.client, dc, namespace, s)   //nolint:errcheck,gosec // best-effort cleanup
 		}
 		// Move all old ignore-sets to ship-set to clear them, then back
 		oldIgnoreSets := extractOldSets(oldPolicy, func(p XDRSetPolicyModel) types.Set { return p.IgnoreSets })
 		for s := range oldIgnoreSets {
-			addXDRDCNamespaceShipSet(r.asConn.client, dc, namespace, s)   //nolint:errcheck // best-effort cleanup
-			addXDRDCNamespaceIgnoreSet(r.asConn.client, dc, namespace, s) //nolint:errcheck // best-effort cleanup
+			addXDRDCNamespaceShipSet(r.asConn.client, dc, namespace, s)   //nolint:errcheck,gosec // best-effort cleanup
+			addXDRDCNamespaceIgnoreSet(r.asConn.client, dc, namespace, s) //nolint:errcheck,gosec // best-effort cleanup
 		}
 	}
 

--- a/internal/provider/resource_aerospike_xdr_dc_config_test.go
+++ b/internal/provider/resource_aerospike_xdr_dc_config_test.go
@@ -854,7 +854,7 @@ func testAccCheckAllNodesXDRNamespaceParam(dc, namespace, key string, expected [
 		for _, node := range nodes {
 			result, err := sendInfoToNode(node, command)
 			if err != nil {
-				return fmt.Errorf("node %s: failed to get XDR namespace config: %s", node.GetName(), err)
+				return fmt.Errorf("node %s: failed to get XDR namespace config: %w", node.GetName(), err)
 			}
 
 			config := make(map[string]string)
@@ -889,7 +889,7 @@ func testAccCheckAllNodesServiceParam(key, expected string) resource.TestCheckFu
 		for _, node := range nodes {
 			result, err := sendInfoToNode(node, command)
 			if err != nil {
-				return fmt.Errorf("node %s: failed to get service config: %s", node.GetName(), err)
+				return fmt.Errorf("node %s: failed to get service config: %w", node.GetName(), err)
 			}
 
 			raw := result[command]
@@ -925,7 +925,7 @@ func testAccCheckXDRDCNamespaceIgnoreSets(dc, namespace string, expected []strin
 
 		config, err := getXDRDCNamespaceConfig(client, dc, namespace)
 		if err != nil {
-			return fmt.Errorf("failed to get XDR DC namespace config: %s", err)
+			return fmt.Errorf("failed to get XDR DC namespace config: %w", err)
 		}
 
 		return compareStringSet(config["ignored-sets"], expected, "ignore-sets")
@@ -943,7 +943,7 @@ func testAccCheckXDRDCNamespaceShipSets(expected []string) resource.TestCheckFun
 
 		config, err := getXDRDCNamespaceConfig(client, "test-dc", "aerospike")
 		if err != nil {
-			return fmt.Errorf("failed to get XDR DC namespace config: %s", err)
+			return fmt.Errorf("failed to get XDR DC namespace config: %w", err)
 		}
 
 		actual := config["shipped-sets"]
@@ -962,7 +962,7 @@ func testAccCheckXDRDCParam(dc, key, expected string) resource.TestCheckFunc {
 
 		config, err := getXDRDCConfig(client, dc)
 		if err != nil {
-			return fmt.Errorf("failed to get XDR DC config: %s", err)
+			return fmt.Errorf("failed to get XDR DC config: %w", err)
 		}
 
 		actual, ok := config[key]
@@ -987,7 +987,7 @@ func testAccCheckXDRDCNamespaceParam(key, expected string) resource.TestCheckFun
 
 		config, err := getXDRDCNamespaceConfig(client, "test-dc", "aerospike")
 		if err != nil {
-			return fmt.Errorf("failed to get XDR DC namespace config: %s", err)
+			return fmt.Errorf("failed to get XDR DC namespace config: %w", err)
 		}
 
 		actual, ok := config[key]

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func main() {
 
 	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
 	flag.Parse()
-	//debug = true
+	// debug = true
 	opts := providerserver.ServeOpts{
 		Address: "registry.terraform.io/hsafra/aerospike",
 		Debug:   debug,


### PR DESCRIPTION
## Summary
- Enable four new golangci-lint linters: `gosec`, `errorlint`, `bodyclose`, `gocritic`
- Fix all 27 reported issues: proper error wrapping (`%w`), `errors.Is` for comparisons, comment formatting
- Add schema validators (`0..MaxUint32`) on role quota fields to prevent integer overflow on `int64→uint32` casts

## Test plan
- [x] `golangci-lint run ./...` passes with 0 issues
- [x] Acceptance tests pass on Aerospike v6, v7, and v8

🤖 Generated with [Claude Code](https://claude.com/claude-code)