### PR TITLE
Fan out config reads to all nodes; detect cross-node drift

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
     name: Terraform Provider Acceptance Tests
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -102,7 +102,7 @@ jobs:
         env:
           TF_ACC: "1"
         run: make testacc
-        timeout-minutes: 10
+        timeout-minutes: 25
       - name: Stop Aerospike containers
         if: always()
         working-directory: tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.5.4
+BUG FIXES:
+* Detect cross-node config drift — reads now fan out to every node and prefer a value differing from prior state when nodes disagree, so `terraform refresh`/`plan` sees the drift and the next apply converges the cluster; per-node values surface as warning diagnostics
+* Absorb momentary network blips — each per-node asinfo call retries once after 500ms before failing
+
+ENHANCEMENTS:
+* Parallelize fan-out reads and non-SMD writes across cluster nodes for faster plan/apply
+* Raise CI acceptance test timeouts to accommodate the larger multi-node test suite
+
 ## 0.5.3
 BUG FIXES:
 * Strip `storage-engine.` subcontext prefix from namespace parameters in `set-config` commands — Aerospike's `get-config` returns these params with the prefix but `set-config` rejects it

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
+	golang.org/x/sync v0.20.0
 )
 
 require (
@@ -83,7 +84,6 @@ require (
 	golang.org/x/exp v0.0.0-20230809150735-7b3493d9a819 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/tools v0.43.0 // indirect

--- a/internal/provider/resource_aerospike_namespace_config.go
+++ b/internal/provider/resource_aerospike_namespace_config.go
@@ -161,8 +161,10 @@ func (r *AerospikeNamespaceConfig) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
-	// Read current namespace config from server
-	serverConfig, err := getNamespaceConfig(r.asConn.client, namespace)
+	// Read current namespace config from every node so cross-node divergence
+	// becomes a planned re-apply rather than a silently-masked drift.
+	priorNsState := stringMapFromTypesMap(data.Params)
+	serverConfig, nsDivergences, err := getNamespaceConfigAllNodes(r.asConn.client, namespace, priorNsState)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading namespace config",
 			fmt.Sprintf("Could not read config for namespace %q: %s", namespace, err.Error()))
@@ -173,6 +175,10 @@ func (r *AerospikeNamespaceConfig) Read(ctx context.Context, req resource.ReadRe
 	// On import, params will be null — we leave it null so only params
 	// declared in the user's HCL config are tracked (avoids drift).
 	if !data.Params.IsNull() {
+		appendDivergenceWarnings(&resp.Diagnostics, nsDivergences, priorNsState,
+			"Namespace parameter differs across cluster nodes",
+			fmt.Sprintf("namespace %q", namespace))
+
 		updatedParams := make(map[string]string)
 		for key := range data.Params.Elements() {
 			if serverVal, ok := serverConfig[key]; ok {
@@ -199,12 +205,17 @@ func (r *AerospikeNamespaceConfig) Read(ctx context.Context, req resource.ReadRe
 				continue
 			}
 
-			serverSetConfig, err := getSetConfig(r.asConn.client, namespace, setName)
+			priorSetState := stringMapFromTypesMap(innerMap)
+			serverSetConfig, setDivergences, err := getSetConfigAllNodes(r.asConn.client, namespace, setName, priorSetState)
 			if err != nil {
 				resp.Diagnostics.AddError("Error reading set config",
 					fmt.Sprintf("Failed to read set config for %s/%s: %s", namespace, setName, err.Error()))
 				return
 			}
+
+			appendDivergenceWarnings(&resp.Diagnostics, setDivergences, priorSetState,
+				"Set parameter differs across cluster nodes",
+				fmt.Sprintf("set %q in namespace %q", setName, namespace))
 
 			setParams := make(map[string]string)
 			for key, val := range innerMap.Elements() {

--- a/internal/provider/resource_aerospike_namespace_config_test.go
+++ b/internal/provider/resource_aerospike_namespace_config_test.go
@@ -428,6 +428,96 @@ func TestAccAerospikeNamespaceConfig_serverDrift(t *testing.T) {
 	})
 }
 
+// #19: Cross-node divergence detection. Writes a different value to a single
+// cluster node out-of-band (bypassing the provider's all-nodes fan-out), then
+// verifies that refresh detects the divergence via getNamespaceConfigAllNodes
+// and produces a non-empty plan, and that the subsequent apply converges all
+// nodes back to the configured value.
+func TestAccAerospikeNamespaceConfig_crossNodeDivergence(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccNamespaceConfigPreCheck(t)
+			testAccRequireMultiNode(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckAerospikeNamespaceConfigDestroy,
+		Steps: []resource.TestStep{
+			// 1. Apply baseline; provider fans out to every node.
+			{
+				Config: testAccNamespaceConfigWithParam("default-ttl", "500"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("aerospike_namespace_config.test", "params.default-ttl", "500"),
+					testAccCheckAllNodesNamespaceParam("aerospike", "default-ttl", "500"),
+				),
+			},
+			// 2. Drive the cluster into a divergent state by writing 777 to a
+			//    single node only — bypasses setNamespaceParam so the other
+			//    nodes keep value 500. Refresh+plan must detect this and
+			//    surface a non-empty plan.
+			{
+				PreConfig: func() {
+					client, err := testAccGetAerospikeClient()
+					if err != nil {
+						t.Fatalf("failed to get client: %s", err)
+					}
+					defer client.Close()
+					nodes := client.GetNodes()
+					if len(nodes) == 0 {
+						t.Fatalf("no cluster nodes available")
+					}
+					_, err = sendInfoToNode(nodes[0], "set-config:context=namespace;id=aerospike;default-ttl=777")
+					if err != nil {
+						t.Fatalf("failed to set divergent value on node %s: %s", nodes[0].GetName(), err)
+					}
+				},
+				Config:             testAccNamespaceConfigWithParam("default-ttl", "500"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+			// 3. Apply: provider re-fans default-ttl=500 to every node and the
+			//    cluster converges.
+			{
+				Config: testAccNamespaceConfigWithParam("default-ttl", "500"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("aerospike_namespace_config.test", "params.default-ttl", "500"),
+					testAccCheckAllNodesNamespaceParam("aerospike", "default-ttl", "500"),
+				),
+			},
+		},
+	})
+}
+
+// testAccCheckAllNodesNamespaceParam verifies a namespace config parameter has
+// the expected value on EVERY cluster node (not just the one the test client
+// happens to land on). Used to assert post-apply convergence.
+func testAccCheckAllNodesNamespaceParam(namespace, key, expected string) resource.TestCheckFunc {
+	return func(_ *terraform.State) error {
+		client, err := testAccGetAerospikeClient()
+		if err != nil {
+			return err
+		}
+		defer client.Close()
+
+		command := "get-config:context=namespace;id=" + namespace
+		for _, node := range client.GetNodes() {
+			result, err := sendInfoToNode(node, command)
+			if err != nil {
+				return fmt.Errorf("node %s: %w", node.GetName(), err)
+			}
+			cfg := parseSemicolonKV(result[command])
+			actual, ok := cfg[key]
+			if !ok {
+				return fmt.Errorf("node %s: namespace %q param %q missing", node.GetName(), namespace, key)
+			}
+			if actual != expected {
+				return fmt.Errorf("node %s: namespace %q param %q: expected %q, got %q",
+					node.GetName(), namespace, key, expected, actual)
+			}
+		}
+		return nil
+	}
+}
+
 func testAccNamespaceConfigMultipleSets() string {
 	return `
 resource "aerospike_namespace_config" "test" {

--- a/internal/provider/resource_aerospike_service_config.go
+++ b/internal/provider/resource_aerospike_service_config.go
@@ -129,8 +129,10 @@ func (r *AerospikeServiceConfig) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	// Read current service config from server
-	serverConfig, err := getServiceConfig(r.asConn.client)
+	// Read current service config from every node so cross-node divergence
+	// becomes a planned re-apply rather than a silently-masked drift.
+	priorState := stringMapFromTypesMap(data.Params)
+	serverConfig, divergences, err := getServiceConfigAllNodes(r.asConn.client, priorState)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading service config",
 			fmt.Sprintf("Could not read service config: %s", err.Error()))
@@ -141,6 +143,9 @@ func (r *AerospikeServiceConfig) Read(ctx context.Context, req resource.ReadRequ
 	// On import, params will be null — we leave it null so only params
 	// declared in the user's HCL config are tracked (avoids drift).
 	if !data.Params.IsNull() {
+		appendDivergenceWarnings(&resp.Diagnostics, divergences, priorState,
+			"Service parameter differs across cluster nodes", "")
+
 		updatedParams := make(map[string]string)
 		for key := range data.Params.Elements() {
 			if serverVal, ok := serverConfig[key]; ok {

--- a/internal/provider/resource_aerospike_xdr_dc_config.go
+++ b/internal/provider/resource_aerospike_xdr_dc_config.go
@@ -236,14 +236,20 @@ func (r *AerospikeXDRDCConfig) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
-	// Read DC-level params
+	// Read DC-level params from every node so cross-node divergence becomes
+	// a planned re-apply rather than a silently-masked drift.
 	if !data.Params.IsNull() {
-		serverConfig, err := getXDRDCConfig(r.asConn.client, dc)
+		priorDCState := stringMapFromTypesMap(data.Params)
+		serverConfig, divergences, err := getXDRDCConfigAllNodes(r.asConn.client, dc, priorDCState)
 		if err != nil {
 			resp.Diagnostics.AddError("Error reading XDR DC config",
 				fmt.Sprintf("Could not read config for DC %q: %s", dc, err.Error()))
 			return
 		}
+
+		appendDivergenceWarnings(&resp.Diagnostics, divergences, priorDCState,
+			"XDR DC parameter differs across cluster nodes",
+			fmt.Sprintf("DC %q", dc))
 
 		updatedParams := make(map[string]string)
 		for key := range data.Params.Elements() {
@@ -267,11 +273,16 @@ func (r *AerospikeXDRDCConfig) Read(ctx context.Context, req resource.ReadReques
 		nsName := ns.Name.ValueString()
 
 		if !ns.Params.IsNull() {
-			serverNsConfig, err := getXDRDCNamespaceConfig(r.asConn.client, dc, nsName)
+			priorNsState := stringMapFromTypesMap(ns.Params)
+			serverNsConfig, divergences, err := getXDRDCNamespaceConfigAllNodes(r.asConn.client, dc, nsName, priorNsState)
 			if err != nil {
 				tflog.Trace(ctx, fmt.Sprintf("could not read XDR DC namespace config for %s/%s: %s", dc, nsName, err.Error()))
 				continue
 			}
+
+			appendDivergenceWarnings(&resp.Diagnostics, divergences, priorNsState,
+				"XDR DC namespace parameter differs across cluster nodes",
+				fmt.Sprintf("namespace %q in DC %q", nsName, dc))
 
 			updatedParams := make(map[string]string)
 			for key := range ns.Params.Elements() {
@@ -289,11 +300,22 @@ func (r *AerospikeXDRDCConfig) Read(ctx context.Context, req resource.ReadReques
 
 		// Read set policy state from server config
 		if len(ns.SetPolicy) > 0 {
-			serverNsConfig, err := getXDRDCNamespaceConfig(r.asConn.client, dc, nsName)
+			// ship-only-specified-sets is a single key; we need the same fan-out
+			// for it. Use prior state derived from the current bool.
+			priorSosVal := "false"
+			if ns.SetPolicy[0].ShipOnlySpecifiedSets.ValueBool() {
+				priorSosVal = "true"
+			}
+			priorSetPolicyState := map[string]string{"ship-only-specified-sets": priorSosVal}
+			serverNsConfig, divergences, err := getXDRDCNamespaceConfigAllNodes(r.asConn.client, dc, nsName, priorSetPolicyState)
 			if err != nil {
 				tflog.Trace(ctx, fmt.Sprintf("could not read XDR DC namespace config for set_policy %s/%s: %s", dc, nsName, err.Error()))
 				continue
 			}
+
+			appendDivergenceWarnings(&resp.Diagnostics, divergences, priorSetPolicyState,
+				"XDR set policy differs across cluster nodes",
+				fmt.Sprintf("namespace %q in DC %q", nsName, dc))
 
 			policy := ns.SetPolicy[0]
 

--- a/internal/provider/utils_as.go
+++ b/internal/provider/utils_as.go
@@ -6,11 +6,14 @@ package provider
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
 	as "github.com/aerospike/aerospike-client-go/v8"
 	astypes "github.com/aerospike/aerospike-client-go/v8/types"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type asCapabilities int
@@ -94,8 +97,26 @@ func sendInfoCommandAllNodesSMD(conn *as.Client, command string) (map[string]str
 	return result, nil
 }
 
-// sendInfoToNode sends an asinfo command to a specific node and checks for errors.
+// infoRetryDelay is the pause before the single retry attempted by
+// sendInfoToNode. Short on purpose: only meant to absorb a momentary
+// network blip, not to mask a real failure.
+const infoRetryDelay = 500 * time.Millisecond
+
+// sendInfoToNode sends an asinfo command to a specific node. On any error
+// it sleeps infoRetryDelay and retries once, so a transient network blip
+// does not fail an entire plan or apply. After the second failure the
+// error is returned and the caller fails fast.
 func sendInfoToNode(node *as.Node, command string) (map[string]string, error) {
+	result, err := sendInfoToNodeOnce(node, command)
+	if err == nil {
+		return result, nil
+	}
+	time.Sleep(infoRetryDelay)
+	return sendInfoToNodeOnce(node, command)
+}
+
+// sendInfoToNodeOnce is a single attempt of an asinfo command — no retries.
+func sendInfoToNodeOnce(node *as.Node, command string) (map[string]string, error) {
 	policy := as.NewInfoPolicy()
 	result, err := node.RequestInfo(policy, command)
 	if err != nil {
@@ -111,6 +132,168 @@ func sendInfoToNode(node *as.Node, command string) (map[string]string, error) {
 	return result, nil
 }
 
+// nodeDivergence describes a single config key whose value differs across
+// nodes. NodeValues maps nodeName -> value (only nodes that reported the
+// key are listed).
+type nodeDivergence struct {
+	Key        string
+	NodeValues map[string]string
+}
+
+// formatNodeValues renders a divergence's per-node values in stable order,
+// suitable for embedding in a diagnostic message.
+func (d nodeDivergence) formatNodeValues() string {
+	names := make([]string, 0, len(d.NodeValues))
+	for n := range d.NodeValues {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	parts := make([]string, 0, len(names))
+	for _, n := range names {
+		parts = append(parts, fmt.Sprintf("%s=%q", n, d.NodeValues[n]))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// stringMapFromTypesMap extracts the string values of a types.Map into a
+// plain map[string]string. Non-string elements and null/unknown values
+// are skipped. Used to derive prior state for reduceNodeConfigs.
+func stringMapFromTypesMap(m types.Map) map[string]string {
+	out := make(map[string]string)
+	if m.IsNull() || m.IsUnknown() {
+		return out
+	}
+	for k, v := range m.Elements() {
+		if s, ok := v.(types.String); ok && !s.IsNull() && !s.IsUnknown() {
+			out[k] = s.ValueString()
+		}
+	}
+	return out
+}
+
+// appendDivergenceWarnings emits one warning diagnostic per divergence whose
+// key is present in `managed` (typically the priorState passed to
+// reduceNodeConfigs, so only user-declared keys produce a warning). `where`
+// is appended to the detail message to identify the context — e.g.
+// "namespace \"foo\"" or "DC \"bar\""; pass "" when the context is implicit
+// (e.g. the cluster-wide service config).
+func appendDivergenceWarnings(diags *diag.Diagnostics, divergences []nodeDivergence, managed map[string]string, summary, where string) {
+	for _, d := range divergences {
+		if _, ok := managed[d.Key]; !ok {
+			continue
+		}
+		var detail string
+		if where == "" {
+			detail = fmt.Sprintf("Parameter %q has different values across cluster nodes: %s. "+
+				"Terraform will re-apply the configured value on the next apply to converge the cluster.",
+				d.Key, d.formatNodeValues())
+		} else {
+			detail = fmt.Sprintf("Parameter %q on %s has different values across cluster nodes: %s. "+
+				"Terraform will re-apply the configured value on the next apply to converge the cluster.",
+				d.Key, where, d.formatNodeValues())
+		}
+		diags.AddWarning(summary, detail)
+	}
+}
+
+// parseSemicolonKV parses a ";"-separated list of "key=value" pairs, the
+// format Aerospike's get-config family returns. Empty or malformed pairs
+// are silently skipped.
+func parseSemicolonKV(raw string) map[string]string {
+	out := make(map[string]string)
+	for _, pair := range strings.Split(raw, ";") {
+		kv := strings.SplitN(pair, "=", 2)
+		if len(kv) == 2 {
+			out[kv[0]] = kv[1]
+		}
+	}
+	return out
+}
+
+// fetchConfigAllNodes runs an asinfo command on every node and parses the
+// response as ";"-separated key=value pairs. Returns nodeName -> key -> value.
+// Fails fast if any node returns an error (after the per-node retry).
+func fetchConfigAllNodes(conn *as.Client, command string) (map[string]map[string]string, error) {
+	nodes := conn.GetNodes()
+	if len(nodes) == 0 {
+		return nil, errors.New("no nodes available in cluster")
+	}
+
+	out := make(map[string]map[string]string, len(nodes))
+	for _, node := range nodes {
+		result, err := sendInfoToNode(node, command)
+		if err != nil {
+			return nil, fmt.Errorf("node %s: %w", node.GetName(), err)
+		}
+		out[node.GetName()] = parseSemicolonKV(result[command])
+	}
+	return out, nil
+}
+
+// reduceNodeConfigs collapses per-node configs into a single config map and
+// reports any keys where nodes disagree. When divergence is detected for a
+// key, the chosen value prefers a node value that differs from priorState
+// for that key — this writes a state that does not match the user's config,
+// so tf-core plans a re-apply that will fan the desired value back out to
+// all nodes. If no node value differs from prior state (or no prior state
+// is known), the most common value wins.
+func reduceNodeConfigs(nodeConfigs map[string]map[string]string, priorState map[string]string) (map[string]string, []nodeDivergence) {
+	keys := make(map[string]struct{})
+	for _, cfg := range nodeConfigs {
+		for k := range cfg {
+			keys[k] = struct{}{}
+		}
+	}
+
+	reduced := make(map[string]string, len(keys))
+	var divergences []nodeDivergence
+
+	for key := range keys {
+		valByNode := make(map[string]string, len(nodeConfigs))
+		counts := make(map[string]int)
+		for nodeName, cfg := range nodeConfigs {
+			v, ok := cfg[key]
+			if !ok {
+				continue
+			}
+			valByNode[nodeName] = v
+			counts[v]++
+		}
+
+		if len(counts) <= 1 {
+			for _, v := range valByNode {
+				reduced[key] = v
+				break
+			}
+			continue
+		}
+
+		divergences = append(divergences, nodeDivergence{Key: key, NodeValues: valByNode})
+
+		chosen, set := "", false
+		if priorVal, hadPrior := priorState[key]; hadPrior {
+			for _, v := range valByNode {
+				if v != priorVal {
+					chosen = v
+					set = true
+					break
+				}
+			}
+		}
+		if !set {
+			bestCount := -1
+			for v, c := range counts {
+				if c > bestCount {
+					bestCount = c
+					chosen = v
+				}
+			}
+		}
+		reduced[key] = chosen
+	}
+	return reduced, divergences
+}
+
 // getNamespaceConfig reads all namespace configuration parameters via get-config and returns them as a map.
 func getNamespaceConfig(conn *as.Client, namespace string) (map[string]string, error) {
 	command := "get-config:context=namespace;id=" + namespace
@@ -118,17 +301,40 @@ func getNamespaceConfig(conn *as.Client, namespace string) (map[string]string, e
 	if err != nil {
 		return nil, err
 	}
+	return parseSemicolonKV(result[command]), nil
+}
 
-	config := make(map[string]string)
-	raw := result[command]
-	pairs := strings.Split(raw, ";")
-	for _, pair := range pairs {
+// getNamespaceConfigAllNodes reads namespace config from every node and
+// returns the reduced map plus any per-key divergences across nodes.
+// priorState is the value previously persisted in Terraform state for the
+// same keys — used to break ties in favor of a value that will force a
+// drift+reapply (see reduceNodeConfigs).
+func getNamespaceConfigAllNodes(conn *as.Client, namespace string, priorState map[string]string) (map[string]string, []nodeDivergence, error) {
+	command := "get-config:context=namespace;id=" + namespace
+	perNode, err := fetchConfigAllNodes(conn, command)
+	if err != nil {
+		return nil, nil, err
+	}
+	reduced, divergences := reduceNodeConfigs(perNode, priorState)
+	return reduced, divergences, nil
+}
+
+// parseColonKV parses a single set entry, formatted as ":"-separated
+// "key=value" pairs (Aerospike's "sets/<ns>/<set>" response format).
+// Any trailing ";" is stripped before parsing.
+func parseColonKV(raw string) map[string]string {
+	out := make(map[string]string)
+	raw = strings.TrimRight(raw, ";")
+	if raw == "" {
+		return out
+	}
+	for _, pair := range strings.Split(raw, ":") {
 		kv := strings.SplitN(pair, "=", 2)
 		if len(kv) == 2 {
-			config[kv[0]] = kv[1]
+			out[kv[0]] = kv[1]
 		}
 	}
-	return config, nil
+	return out
 }
 
 // getSetConfig reads set-level info via "sets/<namespace>/<set>".
@@ -140,21 +346,28 @@ func getSetConfig(conn *as.Client, namespace, setName string) (map[string]string
 	if err != nil {
 		return nil, err
 	}
+	return parseColonKV(result[command]), nil
+}
 
-	config := make(map[string]string)
-	raw := strings.TrimRight(result[command], ";")
-	if raw == "" {
-		return config, nil
+// getSetConfigAllNodes reads set config from every node and returns the
+// reduced map plus per-key divergences (see reduceNodeConfigs). priorState
+// is the previously persisted Terraform state for the same set's keys.
+func getSetConfigAllNodes(conn *as.Client, namespace, setName string, priorState map[string]string) (map[string]string, []nodeDivergence, error) {
+	command := "sets/" + namespace + "/" + setName
+	nodes := conn.GetNodes()
+	if len(nodes) == 0 {
+		return nil, nil, errors.New("no nodes available in cluster")
 	}
-
-	pairs := strings.Split(raw, ":")
-	for _, pair := range pairs {
-		kv := strings.SplitN(pair, "=", 2)
-		if len(kv) == 2 {
-			config[kv[0]] = kv[1]
+	perNode := make(map[string]map[string]string, len(nodes))
+	for _, node := range nodes {
+		result, err := sendInfoToNode(node, command)
+		if err != nil {
+			return nil, nil, fmt.Errorf("node %s: %w", node.GetName(), err)
 		}
+		perNode[node.GetName()] = parseColonKV(result[command])
 	}
-	return config, nil
+	reduced, divergences := reduceNodeConfigs(perNode, priorState)
+	return reduced, divergences, nil
 }
 
 // getValidSetParamKeys returns the set of valid set-level param keys for a namespace.
@@ -242,17 +455,19 @@ func getServiceConfig(conn *as.Client) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	return parseSemicolonKV(result[command]), nil
+}
 
-	config := make(map[string]string)
-	raw := result[command]
-	pairs := strings.Split(raw, ";")
-	for _, pair := range pairs {
-		kv := strings.SplitN(pair, "=", 2)
-		if len(kv) == 2 {
-			config[kv[0]] = kv[1]
-		}
+// getServiceConfigAllNodes reads service config from every node and returns
+// the reduced map plus per-key divergences (see reduceNodeConfigs).
+func getServiceConfigAllNodes(conn *as.Client, priorState map[string]string) (map[string]string, []nodeDivergence, error) {
+	command := "get-config:context=service"
+	perNode, err := fetchConfigAllNodes(conn, command)
+	if err != nil {
+		return nil, nil, err
 	}
-	return config, nil
+	reduced, divergences := reduceNodeConfigs(perNode, priorState)
+	return reduced, divergences, nil
 }
 
 // setServiceParam sets a single service-level configuration parameter via set-config.
@@ -269,17 +484,19 @@ func getXDRDCConfig(conn *as.Client, dc string) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	return parseSemicolonKV(result[command]), nil
+}
 
-	config := make(map[string]string)
-	raw := result[command]
-	pairs := strings.Split(raw, ";")
-	for _, pair := range pairs {
-		kv := strings.SplitN(pair, "=", 2)
-		if len(kv) == 2 {
-			config[kv[0]] = kv[1]
-		}
+// getXDRDCConfigAllNodes reads XDR DC config from every node and returns
+// the reduced map plus per-key divergences (see reduceNodeConfigs).
+func getXDRDCConfigAllNodes(conn *as.Client, dc string, priorState map[string]string) (map[string]string, []nodeDivergence, error) {
+	command := "get-config:context=xdr;dc=" + dc
+	perNode, err := fetchConfigAllNodes(conn, command)
+	if err != nil {
+		return nil, nil, err
 	}
-	return config, nil
+	reduced, divergences := reduceNodeConfigs(perNode, priorState)
+	return reduced, divergences, nil
 }
 
 // getXDRDCNamespaceConfig reads namespace-level XDR configuration for a DC/namespace pair.
@@ -289,17 +506,19 @@ func getXDRDCNamespaceConfig(conn *as.Client, dc, namespace string) (map[string]
 	if err != nil {
 		return nil, err
 	}
+	return parseSemicolonKV(result[command]), nil
+}
 
-	config := make(map[string]string)
-	raw := result[command]
-	pairs := strings.Split(raw, ";")
-	for _, pair := range pairs {
-		kv := strings.SplitN(pair, "=", 2)
-		if len(kv) == 2 {
-			config[kv[0]] = kv[1]
-		}
+// getXDRDCNamespaceConfigAllNodes reads XDR DC namespace config from every
+// node and returns the reduced map plus per-key divergences.
+func getXDRDCNamespaceConfigAllNodes(conn *as.Client, dc, namespace string, priorState map[string]string) (map[string]string, []nodeDivergence, error) {
+	command := "get-config:context=xdr;dc=" + dc + ";namespace=" + namespace
+	perNode, err := fetchConfigAllNodes(conn, command)
+	if err != nil {
+		return nil, nil, err
 	}
-	return config, nil
+	reduced, divergences := reduceNodeConfigs(perNode, priorState)
+	return reduced, divergences, nil
 }
 
 // dcExists checks whether a datacenter exists in the XDR configuration.

--- a/internal/provider/utils_as.go
+++ b/internal/provider/utils_as.go
@@ -8,12 +8,14 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	as "github.com/aerospike/aerospike-client-go/v8"
 	astypes "github.com/aerospike/aerospike-client-go/v8/types"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"golang.org/x/sync/errgroup"
 )
 
 type asCapabilities int
@@ -41,26 +43,35 @@ func sendInfoCommand(conn *as.Client, command string) (map[string]string, error)
 	return sendInfoToNode(node, command)
 }
 
-// sendInfoCommandAllNodes sends an asinfo command to ALL nodes in the cluster.
-// Use this for write commands (set-config, etc.) because Aerospike set-config commands
-// are per-node — they are NOT automatically distributed via SMD to other cluster members.
-// This follows the same approach as asadm, which fans out config commands to every node.
+// sendInfoCommandAllNodes sends an asinfo command to ALL nodes in the cluster
+// in parallel. Use this for write commands (set-config, etc.) because Aerospike
+// set-config commands are per-node — they are NOT automatically distributed via
+// SMD to other cluster members. This follows the same approach as asadm, which
+// fans out config commands to every node. Returns the last node's response for
+// API parity; callers currently only check the error.
 func sendInfoCommandAllNodes(conn *as.Client, command string) (map[string]string, error) { //nolint:unparam // callers may use the result in the future
 	nodes := conn.GetNodes()
 	if len(nodes) == 0 {
 		return nil, errors.New("no nodes available in cluster")
 	}
 
-	var lastResult map[string]string
-	for _, node := range nodes {
-		result, err := sendInfoToNode(node, command)
-		if err != nil {
-			return nil, fmt.Errorf("node %s: %w", node.GetName(), err)
-		}
-		lastResult = result
+	results := make([]map[string]string, len(nodes))
+	var g errgroup.Group
+	for i, node := range nodes {
+		g.Go(func() error {
+			result, err := sendInfoToNode(node, command)
+			if err != nil {
+				return fmt.Errorf("node %s: %w", node.GetName(), err)
+			}
+			results[i] = result
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
 	}
 
-	return lastResult, nil
+	return results[len(results)-1], nil
 }
 
 // smdRaceError is the error Aerospike returns when a structural XDR command
@@ -210,9 +221,10 @@ func parseSemicolonKV(raw string) map[string]string {
 	return out
 }
 
-// fetchConfigAllNodes runs an asinfo command on every node and parses the
-// response as ";"-separated key=value pairs. Returns nodeName -> key -> value.
-// Fails fast if any node returns an error (after the per-node retry).
+// fetchConfigAllNodes runs an asinfo command on every node in parallel and
+// parses the response as ";"-separated key=value pairs. Returns
+// nodeName -> key -> value. Fails fast if any node returns an error (after the
+// per-node retry).
 func fetchConfigAllNodes(conn *as.Client, command string) (map[string]map[string]string, error) {
 	nodes := conn.GetNodes()
 	if len(nodes) == 0 {
@@ -220,12 +232,23 @@ func fetchConfigAllNodes(conn *as.Client, command string) (map[string]map[string
 	}
 
 	out := make(map[string]map[string]string, len(nodes))
+	var mu sync.Mutex
+	var g errgroup.Group
 	for _, node := range nodes {
-		result, err := sendInfoToNode(node, command)
-		if err != nil {
-			return nil, fmt.Errorf("node %s: %w", node.GetName(), err)
-		}
-		out[node.GetName()] = parseSemicolonKV(result[command])
+		g.Go(func() error {
+			result, err := sendInfoToNode(node, command)
+			if err != nil {
+				return fmt.Errorf("node %s: %w", node.GetName(), err)
+			}
+			parsed := parseSemicolonKV(result[command])
+			mu.Lock()
+			out[node.GetName()] = parsed
+			mu.Unlock()
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
 	}
 	return out, nil
 }
@@ -349,9 +372,9 @@ func getSetConfig(conn *as.Client, namespace, setName string) (map[string]string
 	return parseColonKV(result[command]), nil
 }
 
-// getSetConfigAllNodes reads set config from every node and returns the
-// reduced map plus per-key divergences (see reduceNodeConfigs). priorState
-// is the previously persisted Terraform state for the same set's keys.
+// getSetConfigAllNodes reads set config from every node in parallel and
+// returns the reduced map plus per-key divergences (see reduceNodeConfigs).
+// priorState is the previously persisted Terraform state for the same set's keys.
 func getSetConfigAllNodes(conn *as.Client, namespace, setName string, priorState map[string]string) (map[string]string, []nodeDivergence, error) {
 	command := "sets/" + namespace + "/" + setName
 	nodes := conn.GetNodes()
@@ -359,12 +382,23 @@ func getSetConfigAllNodes(conn *as.Client, namespace, setName string, priorState
 		return nil, nil, errors.New("no nodes available in cluster")
 	}
 	perNode := make(map[string]map[string]string, len(nodes))
+	var mu sync.Mutex
+	var g errgroup.Group
 	for _, node := range nodes {
-		result, err := sendInfoToNode(node, command)
-		if err != nil {
-			return nil, nil, fmt.Errorf("node %s: %w", node.GetName(), err)
-		}
-		perNode[node.GetName()] = parseColonKV(result[command])
+		g.Go(func() error {
+			result, err := sendInfoToNode(node, command)
+			if err != nil {
+				return fmt.Errorf("node %s: %w", node.GetName(), err)
+			}
+			parsed := parseColonKV(result[command])
+			mu.Lock()
+			perNode[node.GetName()] = parsed
+			mu.Unlock()
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, nil, err
 	}
 	reduced, divergences := reduceNodeConfigs(perNode, priorState)
 	return reduced, divergences, nil

--- a/internal/provider/utils_as_test.go
+++ b/internal/provider/utils_as_test.go
@@ -3,7 +3,10 @@
 
 package provider
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestStripNamespaceSubcontext(t *testing.T) {
 	tests := []struct {
@@ -29,4 +32,108 @@ func TestStripNamespaceSubcontext(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParseSemicolonKV(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want map[string]string
+	}{
+		{"empty", "", map[string]string{}},
+		{"single", "a=1", map[string]string{"a": "1"}},
+		{"multi", "a=1;b=2;c=3", map[string]string{"a": "1", "b": "2", "c": "3"}},
+		{"value contains equals", "a=k=v;b=2", map[string]string{"a": "k=v", "b": "2"}},
+		{"malformed pairs skipped", "a=1;bogus;b=2", map[string]string{"a": "1", "b": "2"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseSemicolonKV(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseSemicolonKV(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseColonKV(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want map[string]string
+	}{
+		{"empty", "", map[string]string{}},
+		{"trailing semicolon stripped", "a=1:b=2;", map[string]string{"a": "1", "b": "2"}},
+		{"no trailing semicolon", "a=1:b=2", map[string]string{"a": "1", "b": "2"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseColonKV(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseColonKV(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReduceNodeConfigs(t *testing.T) {
+	t.Run("all nodes agree returns shared value, no divergence", func(t *testing.T) {
+		nodes := map[string]map[string]string{
+			"n1": {"k": "v"},
+			"n2": {"k": "v"},
+		}
+		reduced, div := reduceNodeConfigs(nodes, map[string]string{"k": "v"})
+		if reduced["k"] != "v" {
+			t.Errorf("reduced[k] = %q, want %q", reduced["k"], "v")
+		}
+		if len(div) != 0 {
+			t.Errorf("expected no divergences, got %v", div)
+		}
+	})
+
+	t.Run("disagreement picks value differing from prior state", func(t *testing.T) {
+		nodes := map[string]map[string]string{
+			"n1": {"k": "configured"}, // matches prior state / config
+			"n2": {"k": "drifted"},    // diverging — should be chosen
+		}
+		reduced, div := reduceNodeConfigs(nodes, map[string]string{"k": "configured"})
+		if reduced["k"] != "drifted" {
+			t.Errorf("reduced[k] = %q, want %q (the value that differs from prior state)", reduced["k"], "drifted")
+		}
+		if len(div) != 1 || div[0].Key != "k" {
+			t.Fatalf("expected one divergence on key %q, got %v", "k", div)
+		}
+		if div[0].NodeValues["n1"] != "configured" || div[0].NodeValues["n2"] != "drifted" {
+			t.Errorf("unexpected per-node values: %v", div[0].NodeValues)
+		}
+	})
+
+	t.Run("disagreement with no prior state falls back to most common", func(t *testing.T) {
+		nodes := map[string]map[string]string{
+			"n1": {"k": "a"},
+			"n2": {"k": "b"},
+			"n3": {"k": "b"},
+		}
+		reduced, div := reduceNodeConfigs(nodes, nil)
+		if reduced["k"] != "b" {
+			t.Errorf("reduced[k] = %q, want most common %q", reduced["k"], "b")
+		}
+		if len(div) != 1 {
+			t.Errorf("expected one divergence, got %d", len(div))
+		}
+	})
+
+	t.Run("missing key on some nodes is not divergence if remaining agree", func(t *testing.T) {
+		nodes := map[string]map[string]string{
+			"n1": {"k": "v"},
+			"n2": {}, // didn't report the key
+		}
+		reduced, div := reduceNodeConfigs(nodes, nil)
+		if reduced["k"] != "v" {
+			t.Errorf("reduced[k] = %q, want %q", reduced["k"], "v")
+		}
+		if len(div) != 0 {
+			t.Errorf("expected no divergence when only one node reported, got %v", div)
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- Config reads now fan out to every cluster node instead of hitting a single random one. When nodes disagree on a key's value the reducer prefers a value that differs from prior state, so tf-core sees drift and plans a re-apply that converges the cluster. A warning diagnostic lists per-node values so users can see why the plan appeared.
- `sendInfoToNode` now retries once after 500ms on any error, absorbing transient network blips without changing the existing fail-fast behavior on the second attempt. Applies uniformly to reads and writes (existing fan-out write helpers reuse `sendInfoToNode`).
- All six divergence-warning emission sites (service, namespace params, namespace set params, XDR DC, XDR DC namespace, XDR `ship-only-specified-sets`) collapse into a single `appendDivergenceWarnings` helper.

## Test plan
- [x] Unit tests added for `parseSemicolonKV`, `parseColonKV`, and all four `reduceNodeConfigs` branches (agreement, divergence-with-prior-state, divergence-without-prior-state, partial reporting).
- [x] New acceptance test `TestAccAerospikeNamespaceConfig_crossNodeDivergence` writes a divergent value to one node out-of-band, asserts refresh produces a non-empty plan, and asserts apply converges every node back to the configured value.
- [x] Full v8 acceptance suite (81 tests) PASS against a 3-node source cluster + 2-node XDR target via `make localtestacc-8`. Run took ~11 min, coverage 82%.
- [x] `go build`, `go vet`, `golangci-lint run` all clean.
- [ ] Suggest running v6 and v7 suites before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)